### PR TITLE
strerror_r: posix returns int, gnu returns string

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ To update this project dependencies:
 ```bash
 zig fetch --save=upstream git+https://github.com/postgres/postgres#REL_16_4
 zig fetch --save          git+https://github.com/allyourcodebase/openssl#3.3.0
-zig fetch --save          git+https://github.com/allyourcodebase/libressl#3.9.2+1
+zig fetch --save          git+https://github.com/allyourcodebase/libressl#4.0.0+1
 zig fetch --save          git+https://github.com/allyourcodebase/zlib#1.3.1
-zig fetch --save          git+https://github.com/allyourcodebase/zstd#1.5.6-1
+zig fetch --save          git+https://github.com/allyourcodebase/zstd#1.5.6-2
 ```

--- a/build.zig
+++ b/build.zig
@@ -62,7 +62,6 @@ pub fn build(b: *std.Build) !void {
     lib.addIncludePath(upstream.path("src/include"));
     lib.addIncludePath(b.path("include"));
     lib.addConfigHeader(config_path);
-    lib.root_module.addCMacro("_GNU_SOURCE", "1");
     lib.root_module.addCMacro("FRONTEND", "1");
     lib.linkLibC();
     b.installArtifact(lib);
@@ -74,6 +73,11 @@ pub fn build(b: *std.Build) !void {
 
     var use_openssl: ?u8 = null;
     var use_ssl: ?u8 = null;
+    var not_gnu: ?u8 = null;
+
+    if (target.result.isGnu()) {
+        lib.root_module.addCMacro("_GNU_SOURCE", "1");
+    } else not_gnu = 1;
 
     switch (ssl_option) {
         .OpenSSL => {
@@ -108,6 +112,7 @@ pub fn build(b: *std.Build) !void {
         .HAVE_HMAC_CTX_FREE = use_ssl,
         .HAVE_HMAC_CTX_NEW = use_ssl,
         .HAVE_ASN1_STRING_GET0_DATA = use_ssl,
+        .STRERROR_R_INT = not_gnu,
     });
 
     if (ssl_option != .None) {
@@ -191,7 +196,6 @@ pub fn build(b: *std.Build) !void {
         pg_config.addValues(.{
             .HAVE_EXPLICIT_BZERO = 1,
             .HAVE_STRCHRNUL = 1,
-            .HAVE_STRERROR_R = 1,
             .HAVE_STRINGS_H = 1,
             .HAVE_SYNC_FILE_RANGE = 1,
             .HAVE_MEMSET_S = null,
@@ -201,7 +205,6 @@ pub fn build(b: *std.Build) !void {
         pg_config.addValues(.{
             .HAVE_EXPLICIT_BZERO = null,
             .HAVE_STRCHRNUL = null,
-            .HAVE_STRERROR_R = null,
             .HAVE_STRINGS_H = 0,
             .HAVE_SYNC_FILE_RANGE = null,
             .HAVE_MEMSET_S = 1,
@@ -456,6 +459,7 @@ const autoconf = .{
     .HAVE_STDLIB_H = 1,
     .HAVE_STRING_H = 1,
     .HAVE_STRNLEN = 1,
+    .HAVE_STRERROR_R = 1,
     .HAVE_STRSIGNAL = 1,
     .HAVE_STRUCT_OPTION = 1,
     .HAVE_STRUCT_TM_TM_ZONE = 1,
@@ -580,7 +584,6 @@ const autoconf = .{
     .LOCALE_T_IN_XLOCALE = null,
     .PROFILE_PID_DIR = null,
     .PTHREAD_CREATE_JOINABLE = null,
-    .STRERROR_R_INT = null, // 1 if not _GNU_SOURCE
     .USE_ARMV8_CRC32C = null,
     .USE_ARMV8_CRC32C_WITH_RUNTIME_CHECK = null,
     .USE_ASSERT_CHECKING = null,

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -12,8 +12,8 @@
             .lazy = true,
         },
         .libressl = .{
-            .url = "git+https://github.com/allyourcodebase/libressl?ref=3.9.2+1#02abfefee4e4eda28ce53c637b3c0d204ace8a6d",
-            .hash = "12201f5cc06c88f191696106723797449baacb6ea38b07b6cf31c18c0382a6bea33e",
+            .url = "git+https://github.com/allyourcodebase/libressl?ref=4.0.0+1#fd0fe777153a75217e97ba22cd8b32005bb90d08",
+            .hash = "1220c6521dd6d37f0426fbe6c3b3c3f4282f28495311abc08fb4cebf21ea2346ba2f",
             .lazy = true,
         },
         .zlib = .{
@@ -22,8 +22,8 @@
             .lazy = true,
         },
         .zstd = .{
-            .url = "git+https://github.com/allyourcodebase/zstd?ref=1.5.6-1#3247ffbcbc31f014027a5776a25c4261054e9fe9",
-            .hash = "12200dbfe91946451bab186f584edbec9f9f7fdbcf818ad984b7182fea655b3c10e3",
+            .url = "git+https://github.com/allyourcodebase/zstd?ref=1.5.6-2#ea25e89037dc251a3ba50a5005e2c8566eb3c2bd",
+            .hash = "122040924472b1c510a7058596d43fb9461dcc20406f681eb9c2f6443375d2f571c4",
             .lazy = true,
         },
     },


### PR DESCRIPTION
Improve cross-compilation by checking the target libc (and not just the OS)

In particular fix compiling on macOS targeting linux